### PR TITLE
Scale mean variance

### DIFF
--- a/src/scanpy/preprocessing/_utils.py
+++ b/src/scanpy/preprocessing/_utils.py
@@ -50,7 +50,7 @@ def _get_mean_var(
 
 @numba.njit(cache=True, parallel=True)
 def _compute_mean_var(
-    X, axis: Literal[0, 1] = 0, n_threads=1
+    X: _SupportedArray, axis: Literal[0, 1] = 0, n_threads=1
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     if axis == 0:
         axis_i = 1


### PR DESCRIPTION
500k x 5k AnnData benchmark with an AMD 5950x

Axis= 0 
Intel_kernel = 223 ms
new = 223 ms

Axis= 1
Intel_kernel = 3.35 s
new = 203 ms

This implementation has better memory access for axis= 1. 